### PR TITLE
Add window sql support

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorUtil.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorUtil.java
@@ -110,6 +110,10 @@ public class AggregatorUtil
   public static final byte HLL_SKETCH_TO_STRING_CACHE_TYPE_ID = 0x31;
   public static final byte HLL_SKETCH_TO_ESTIMATE_AND_BOUNDS_CACHE_TYPE_ID = 0x32;
 
+  // LEAD/LAG aggregator
+  public static final byte LEAD_AGG_CACHE_TYPE_ID = 0x5A;
+  public static final byte LAG_AGG_CACHE_TYPE_ID = 0x5B;
+
   /**
    * returns the list of dependent postAggregators that should be calculated in order to calculate given postAgg
    *

--- a/processing/src/main/java/org/apache/druid/query/window/GroupByOverWindowBaseQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/window/GroupByOverWindowBaseQuery.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.window;
+
+import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.groupby.GroupByQuery;
+import org.apache.druid.query.groupby.having.HavingSpec;
+import org.apache.druid.query.groupby.orderby.LimitSpec;
+import org.apache.druid.query.spec.QuerySegmentSpec;
+import org.apache.druid.segment.VirtualColumns;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An abstract class for a query with GroupBy over a Window subquery.
+ * The actual implementation is defined in the extension.
+ */
+public abstract class GroupByOverWindowBaseQuery extends GroupByQuery
+{
+  public GroupByOverWindowBaseQuery(
+      DataSource dataSource,
+      QuerySegmentSpec querySegmentSpec,
+      VirtualColumns virtualColumns,
+      DimFilter dimFilter,
+      Granularity granularity,
+      List<DimensionSpec> dimensions,
+      List<AggregatorFactory> aggregatorSpecs,
+      List<PostAggregator> postAggregatorSpecs,
+      HavingSpec havingSpec,
+      LimitSpec limitSpec,
+      List<List<String>> subtotalsSpec,
+      Map<String, Object> context
+  )
+  {
+    super(
+        dataSource,
+        querySegmentSpec,
+        virtualColumns,
+        dimFilter,
+        granularity,
+        dimensions,
+        aggregatorSpecs,
+        postAggregatorSpecs,
+        havingSpec,
+        limitSpec,
+        subtotalsSpec,
+        context
+    );
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/window/WindowBaseQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/window/WindowBaseQuery.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.window;
+
+import org.apache.druid.data.input.Row;
+import org.apache.druid.query.BaseQuery;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.spec.QuerySegmentSpec;
+
+import java.util.Map;
+
+/**
+ * An abstract class for a query with Window clauses.
+ * The actual implementation is defined in the extension.
+ */
+
+public abstract class WindowBaseQuery extends BaseQuery<Row>
+{
+  public WindowBaseQuery(
+      DataSource dataSource,
+      QuerySegmentSpec querySegmentSpec,
+      boolean descending,
+      Map<String, Object> context)
+  {
+    super(dataSource, querySegmentSpec, descending, context);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/window/WindowQueryFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/window/WindowQueryFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.window;
+
+import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.groupby.having.HavingSpec;
+import org.apache.druid.query.groupby.orderby.LimitSpec;
+import org.apache.druid.query.spec.QuerySegmentSpec;
+import org.apache.druid.segment.VirtualColumns;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An interface to define the APIs to construct a WindowBaseQuery
+ * and a GroupByOverWindowBaseQuery. The actual implementation of
+ * these APIs is defined in the extension.
+ */
+public interface WindowQueryFactory
+{
+  WindowBaseQuery factorize(DataSource dataSource,
+                            QuerySegmentSpec querySegmentSpec,
+                            List<DimensionSpec> dimensions,
+                            List<AggregatorFactory> aggregations,
+                            List<PostAggregator> postAggregators,
+                            List<DimensionSpec> partitions,
+                            DimFilter dimFilter,
+                            LimitSpec limitSpec,
+                            Map<String, Object> queryContext);
+
+  GroupByOverWindowBaseQuery factorize(DataSource dataSource,
+                                       QuerySegmentSpec querySegmentSpec,
+                                       VirtualColumns virtualColumns,
+                                       DimFilter dimFilter,
+                                       Granularity granularity,
+                                       List<DimensionSpec> dimensions,
+                                       List<AggregatorFactory> aggregatorSpecs,
+                                       List<PostAggregator> postAggregatorSpecs,
+                                       HavingSpec havingSpec,
+                                       LimitSpec limitSpec,
+                                       List<List<String>> subtotalsSpec,
+                                       Map<String, Object> context);
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
@@ -100,7 +100,8 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
         druidTable.getRowSignature(),
         getPlannerContext(),
         getCluster().getRexBuilder(),
-        finalizeAggregations
+        finalizeAggregations,
+        false
     );
   }
 
@@ -227,6 +228,14 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
 
     if (partialQuery.getAggregateProject() != null) {
       cost += COST_PER_COLUMN * partialQuery.getAggregateProject().getChildExps().size();
+    }
+
+    if (partialQuery.getWindow() != null) {
+      cost += COST_PER_COLUMN * partialQuery.getWindow().groups.get(0).aggCalls.size();
+    }
+
+    if (partialQuery.getWindowProject() != null) {
+      cost += COST_PER_COLUMN * partialQuery.getWindowProject().getChildExps().size();
     }
 
     if (partialQuery.getSort() != null && partialQuery.getSort().fetch != null) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidSemiJoin.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidSemiJoin.java
@@ -375,6 +375,14 @@ public class DruidSemiJoin extends DruidRel<DruidSemiJoin>
         newPartialQuery = newPartialQuery.withAggregateProject(leftPartialQuery.getAggregateProject());
       }
 
+      if (leftPartialQuery.getWindow() != null) {
+        newPartialQuery = newPartialQuery.withWindow(leftPartialQuery.getWindow());
+      }
+
+      if (leftPartialQuery.getWindowProject() != null) {
+        newPartialQuery = newPartialQuery.withWindowProject(leftPartialQuery.getWindowProject());
+      }
+
       if (leftPartialQuery.getSortProject() != null) {
         newPartialQuery = newPartialQuery.withSortProject(leftPartialQuery.getSortProject());
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rel;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.sql.calcite.aggregation.Aggregation;
+import org.apache.druid.sql.calcite.aggregation.DimensionExpression;
+import org.apache.druid.sql.calcite.table.RowSignature;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class Windowing
+{
+
+  private final List<DimensionExpression> dimensions;
+  private final List<Aggregation> aggregations;
+  private final List<DimensionExpression> partitions;
+  private final RowSignature outputRowSignature;
+
+  private Windowing(
+      final List<DimensionExpression> dimensions,
+      final List<Aggregation> aggregations,
+      final List<DimensionExpression> partitions,
+      final RowSignature outputRowSignature
+  )
+  {
+    this.dimensions = ImmutableList.copyOf(dimensions);
+    this.aggregations = ImmutableList.copyOf(aggregations);
+    this.partitions = partitions;
+    this.outputRowSignature = outputRowSignature;
+
+    // Verify no collisions.
+    final Set<String> seen = Sets.newHashSet();
+    for (DimensionExpression dimensionExpression : dimensions) {
+      if (!seen.add(dimensionExpression.getOutputName())) {
+        throw new ISE("Duplicate field name: %s", dimensionExpression.getOutputName());
+      }
+    }
+
+    for (Aggregation aggregation : aggregations) {
+      for (AggregatorFactory aggregatorFactory : aggregation.getAggregatorFactories()) {
+        if (!seen.add(aggregatorFactory.getName())) {
+          throw new ISE("Duplicate field name: %s", aggregatorFactory.getName());
+        }
+      }
+      if (aggregation.getPostAggregator() != null && !seen.add(aggregation.getPostAggregator().getName())) {
+        throw new ISE("Windowing aggregate function post aggregator missing field %s",
+                      aggregation.getPostAggregator().getName());
+      }
+    }
+
+    // Verify that items in the output signature exist.
+    for (final String field : outputRowSignature.getRowOrder()) {
+      if (!seen.contains(field)) {
+        throw new ISE("Missing field in rowOrder: %s", field);
+      }
+    }
+  }
+
+  public static Windowing create(
+      final List<DimensionExpression> dimensions,
+      final List<Aggregation> aggregations,
+      final List<DimensionExpression> partitions,
+      final RowSignature outputRowSignature
+  )
+  {
+    return new Windowing(dimensions, aggregations, partitions, outputRowSignature);
+  }
+
+  public List<DimensionExpression> getDimensions()
+  {
+    return dimensions;
+  }
+
+  public List<Aggregation> getAggregations()
+  {
+    return aggregations;
+  }
+
+  public List<PostAggregator> getPostAggregators()
+  {
+    return aggregations.stream()
+                       .map(Aggregation::getPostAggregator)
+                       .filter(Objects::nonNull)
+                       .collect(Collectors.toList());
+  }
+
+  public RowSignature getOutputRowSignature()
+  {
+    return outputRowSignature;
+  }
+
+  public List<DimensionSpec> getDimensionSpecs()
+  {
+    return dimensions.stream()
+                     .map(DimensionExpression::toDimensionSpec)
+                     .collect(Collectors.toList());
+  }
+
+  public List<DimensionSpec> getPartitionSpecs()
+  {
+    return partitions.stream()
+                     .map(DimensionExpression::toDimensionSpec)
+                     .collect(Collectors.toList());
+  }
+
+  public List<AggregatorFactory> getAggregatorFactories()
+  {
+    return aggregations.stream()
+                       .flatMap(aggregation -> aggregation.getAggregatorFactories().stream())
+                       .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Windowing window = (Windowing) o;
+    return Objects.equals(dimensions, window.dimensions) &&
+           Objects.equals(aggregations, window.aggregations) &&
+           Objects.equals(partitions, window.partitions) &&
+           Objects.equals(outputRowSignature, window.outputRowSignature);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(dimensions, aggregations, partitions, outputRowSignature);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "Windowing{" +
+           "dimensions=" + dimensions +
+           ", aggregations=" + aggregations +
+           ", partitions=" + partitions +
+           ", outputRowSignature=" + outputRowSignature +
+           '}';
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRules.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.Window;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.sql.calcite.rel.DruidOuterQueryRel;
 import org.apache.druid.sql.calcite.rel.DruidRel;
@@ -63,6 +64,16 @@ public class DruidRules
             Sort.class,
             PartialDruidQuery.Stage.SELECT_SORT,
             PartialDruidQuery::withSelectSort
+        ),
+        new DruidQueryRule<>(
+            Window.class,
+            PartialDruidQuery.Stage.WINDOW,
+            PartialDruidQuery::withWindow
+        ),
+        new DruidQueryRule<>(
+            Project.class,
+            PartialDruidQuery.Stage.WINDOW_PROJECT,
+            PartialDruidQuery::withWindowProject
         ),
         new DruidQueryRule<>(
             Aggregate.class,
@@ -278,9 +289,9 @@ public class DruidRules
     @Override
     public boolean matches(final RelOptRuleCall call)
     {
-      // Subquery must be a groupBy, so stage must be >= AGGREGATE.
+      // Subquery must be a groupBy/window, so stage must be >= WINDOW.
       final DruidRel druidRel = call.rel(call.getRelList().size() - 1);
-      return druidRel.getPartialDruidQuery().stage().compareTo(PartialDruidQuery.Stage.AGGREGATE) >= 0;
+      return druidRel.getPartialDruidQuery().stage().compareTo(PartialDruidQuery.Stage.WINDOW) >= 0;
     }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -128,7 +128,9 @@ public class SqlResource
                         for (int i = 0; i < fieldList.size(); i++) {
                           final Object value;
 
-                          if (timeColumns[i]) {
+                          if (row[i] == null) {
+                            value = row[i];
+                          } else if (timeColumns[i]) {
                             value = ISODateTimeFormat.dateTime().print(
                                 Calcites.calciteTimestampToJoda((long) row[i], timeZone)
                             );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/window/MockWindowQueryFactory.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/window/MockWindowQueryFactory.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.window;
+
+import org.apache.druid.data.input.Row;
+import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.PerSegmentQueryOptimizationContext;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.groupby.having.HavingSpec;
+import org.apache.druid.query.groupby.orderby.LimitSpec;
+import org.apache.druid.query.spec.QuerySegmentSpec;
+import org.apache.druid.query.window.GroupByOverWindowBaseQuery;
+import org.apache.druid.query.window.WindowBaseQuery;
+import org.apache.druid.query.window.WindowQueryFactory;
+import org.apache.druid.segment.VirtualColumns;
+
+import java.util.List;
+import java.util.Map;
+
+public class MockWindowQueryFactory implements WindowQueryFactory
+{
+  public class MockWindowQuery extends WindowBaseQuery
+  {
+    public MockWindowQuery(
+        DataSource dataSource, QuerySegmentSpec querySegmentSpec, boolean descending, Map<String, Object> context
+    )
+    {
+      super(dataSource, querySegmentSpec, descending, context);
+    }
+
+    @Override
+    public DimFilter getFilter()
+    {
+      return null;
+    }
+
+    @Override
+    public Query<Row> withQuerySegmentSpec(QuerySegmentSpec spec)
+    {
+      return null;
+    }
+
+    @Override
+    public Query<Row> withDataSource(DataSource dataSource)
+    {
+      return null;
+    }
+
+    @Override
+    public String getType()
+    {
+      return null;
+    }
+
+    @Override
+    public boolean hasFilters()
+    {
+      return false;
+    }
+
+    @Override
+    public Query<Row> withOverriddenContext(Map<String, Object> contextOverride)
+    {
+      return null;
+    }
+
+    @Override
+    public Query<Row> optimizeForSegment(PerSegmentQueryOptimizationContext optimizationContext)
+    {
+      return null;
+    }
+  }
+
+  public class MockGroupByOverWindowQuery extends GroupByOverWindowBaseQuery
+  {
+    public MockGroupByOverWindowQuery(
+        DataSource dataSource,
+        QuerySegmentSpec querySegmentSpec,
+        VirtualColumns virtualColumns,
+        DimFilter dimFilter,
+        Granularity granularity,
+        List<DimensionSpec> dimensions,
+        List<AggregatorFactory> aggregatorSpecs,
+        List<PostAggregator> postAggregatorSpecs,
+        HavingSpec havingSpec,
+        LimitSpec limitSpec,
+        List<List<String>> subtotalsSpec,
+        Map<String, Object> context
+    )
+    {
+      super(
+          dataSource,
+          querySegmentSpec,
+          virtualColumns,
+          dimFilter,
+          granularity,
+          dimensions,
+          aggregatorSpecs,
+          postAggregatorSpecs,
+          havingSpec,
+          limitSpec,
+          subtotalsSpec,
+          context
+      );
+    }
+  }
+
+
+
+  @Override
+  public WindowBaseQuery factorize(
+      DataSource dataSource, QuerySegmentSpec querySegmentSpec,
+      List<DimensionSpec> dimensions,
+      List<AggregatorFactory> aggregations,
+      List<PostAggregator> postAggregators,
+      List<DimensionSpec> partitions, DimFilter dimFilter,
+      LimitSpec limitSpec, Map<String, Object> queryContext
+  )
+  {
+    return new MockWindowQuery(dataSource, querySegmentSpec, true, queryContext);
+  }
+
+  @Override
+  public GroupByOverWindowBaseQuery factorize(
+      DataSource dataSource,
+      QuerySegmentSpec querySegmentSpec,
+      VirtualColumns virtualColumns,
+      DimFilter dimFilter,
+      Granularity granularity,
+      List<DimensionSpec> dimensions,
+      List<AggregatorFactory> aggregatorSpecs,
+      List<PostAggregator> postAggregatorSpecs,
+      HavingSpec havingSpec, LimitSpec limitSpec,
+      List<List<String>> subtotalsSpec,
+      Map<String, Object> context
+  )
+  {
+    return new MockGroupByOverWindowQuery(dataSource, querySegmentSpec, virtualColumns,
+                                          dimFilter, granularity, dimensions, aggregatorSpecs,
+                                          postAggregatorSpecs, havingSpec, limitSpec, subtotalsSpec,
+                                          context
+    );
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/window/WindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/window/WindowQueryTest.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.window;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLeadLagAggFunction;
+import org.apache.calcite.tools.ValidationException;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.QueryRunnerFactoryConglomerate;
+import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.sql.calcite.aggregation.Aggregation;
+import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.Expressions;
+import org.apache.druid.sql.calcite.planner.DruidOperatorTable;
+import org.apache.druid.sql.calcite.planner.DruidPlanner;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.planner.PlannerFactory;
+import org.apache.druid.sql.calcite.planner.PlannerResult;
+import org.apache.druid.sql.calcite.rel.DruidQuery;
+import org.apache.druid.sql.calcite.schema.DruidSchema;
+import org.apache.druid.sql.calcite.schema.SystemSchema;
+import org.apache.druid.sql.calcite.table.RowSignature;
+import org.apache.druid.sql.calcite.util.CalciteTestBase;
+import org.apache.druid.sql.calcite.util.CalciteTests;
+import org.apache.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
+import org.apache.druid.sql.calcite.view.InProcessViewManager;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nullable;
+
+import static org.junit.Assert.assertTrue;
+
+public class WindowQueryTest extends CalciteTestBase
+{
+  private static final Logger log = new Logger(WindowQueryTest.class);
+
+  private static final PlannerConfig PLANNER_CONFIG_DEFAULT = new PlannerConfig();
+  private static final Map<String, Object> QUERY_CONTEXT_DEFAULT = ImmutableMap.of(
+      PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
+  );
+  private static QueryRunnerFactoryConglomerate conglomerate;
+  private static Closer resourceCloser;
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private SpecificSegmentsQuerySegmentWalker walker = null;
+
+  public abstract static class MockWindowAggregatorFactory extends AggregatorFactory
+  {
+    @Override
+    public Aggregator factorize(ColumnSelectorFactory metricFactory)
+    {
+      return null;
+    }
+
+    @Override
+    public BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory)
+    {
+      return null;
+    }
+
+    @Override
+    public Comparator getComparator()
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Object combine(@Nullable Object lhs, @Nullable Object rhs)
+    {
+      return null;
+    }
+
+    @Override
+    public AggregatorFactory getCombiningFactory()
+    {
+      return null;
+    }
+
+    @Override
+    public List<AggregatorFactory> getRequiredColumns()
+    {
+      return null;
+    }
+
+    @Override
+    public Object deserialize(Object object)
+    {
+      return null;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Object finalizeComputation(@Nullable Object object)
+    {
+      return null;
+    }
+
+    @Override
+    public List<String> requiredFields()
+    {
+      return null;
+    }
+
+    @Override
+    public int getMaxIntermediateSize()
+    {
+      return 0;
+    }
+
+    @Override
+    public byte[] getCacheKey()
+    {
+      return new byte[0];
+    }
+  }
+
+  public static class MockLeadAggregatorFactory extends MockWindowAggregatorFactory
+  {
+    private String name;
+    private String fieldName;
+
+    public MockLeadAggregatorFactory(String name, String fieldName)
+    {
+      this.name = name;
+      this.fieldName = fieldName;
+    }
+
+    @Override
+    public String getName()
+    {
+      return name;
+    }
+  }
+
+  public static class MockLagAggregatorFactory extends MockWindowAggregatorFactory
+  {
+    private String name;
+    private String fieldName;
+
+    public MockLagAggregatorFactory(String name, String fieldName)
+    {
+      this.name = name;
+      this.fieldName = fieldName;
+    }
+
+    @Override
+    public String getName()
+    {
+      return name;
+    }
+  }
+
+  public static class SqlWindowAggregator implements SqlAggregator
+  {
+    private SqlKind sqlKind;
+
+    public SqlWindowAggregator(SqlKind sqlKind)
+    {
+      this.sqlKind = sqlKind;
+    }
+
+    public static List<DruidExpression> getArgumentsForWindowAggregator(
+        PlannerContext plannerContext, RowSignature rowSignature, AggregateCall call,
+        Project project
+    )
+    {
+      return (List) call.getArgList().stream().map((i) -> {
+        return Expressions.fromFieldAccess(rowSignature, project, i.intValue());
+      }).map((rexNode) -> {
+        return toDruidExpressionForWindowAggregator(plannerContext, rowSignature, rexNode);
+      }).collect(Collectors.toList());
+    }
+
+    private static DruidExpression toDruidExpressionForWindowAggregator(
+        PlannerContext plannerContext, RowSignature rowSignature, RexNode rexNode
+    )
+    {
+      DruidExpression druidExpression =
+          Expressions.toDruidExpression(plannerContext, rowSignature, rexNode);
+      if (druidExpression == null) {
+        return null;
+      } else {
+        return !druidExpression.isSimpleExtraction() || druidExpression.isDirectColumnAccess()
+               ? druidExpression
+               : druidExpression.map((simpleExtraction) -> {
+                 return null;
+               }, Function.identity());
+      }
+    }
+
+    public static AggregatorFactory createWindowAggregatorFactory(
+        SqlKind sqlKind,
+        String name,
+        String fieldName
+    )
+    {
+      switch (sqlKind) {
+        case LEAD:
+          return new MockLeadAggregatorFactory(name, fieldName);
+
+        case LAG:
+          return new MockLagAggregatorFactory(name, fieldName);
+        default:
+          throw new ISE("Do not support window aggregator %s", sqlKind);
+      }
+    }
+
+    @Override
+    public SqlAggFunction calciteFunction()
+    {
+      return new SqlLeadLagAggFunction(sqlKind);
+    }
+
+    @Nullable
+    @Override
+    public Aggregation toDruidAggregation(
+        PlannerContext plannerContext,
+        RowSignature rowSignature,
+        RexBuilder rexBuilder,
+        String s,
+        AggregateCall aggregateCall,
+        Project project,
+        List<Aggregation> list,
+        boolean b
+    )
+    {
+      final List<DruidExpression> arguments = getArgumentsForWindowAggregator(
+          plannerContext,
+          rowSignature,
+          aggregateCall,
+          project
+      );
+
+      if (arguments == null) {
+        return null;
+      }
+
+      final DruidExpression arg = Iterables.getOnlyElement(arguments);
+
+      final String fieldName;
+
+      if (arg.isDirectColumnAccess()) {
+        fieldName = arg.getDirectColumn();
+      } else {
+        throw new ISE("must use a column in LEAD/LAG");
+      }
+
+      return Aggregation.create(createWindowAggregatorFactory(sqlKind, s, fieldName));
+    }
+  }
+
+  public static class MockSqlLag extends SqlWindowAggregator
+  {
+    public MockSqlLag()
+    {
+      super(SqlKind.LAG);
+    }
+  }
+
+  public static class MockSqlLead extends SqlWindowAggregator
+  {
+    public MockSqlLead()
+    {
+      super(SqlKind.LEAD);
+    }
+  }
+
+  @BeforeClass
+  public static void setUpClass()
+  {
+    final Pair<QueryRunnerFactoryConglomerate, Closer> conglomerateCloserPair = CalciteTests
+        .createQueryRunnerFactoryConglomerate();
+    conglomerate = conglomerateCloserPair.lhs;
+    resourceCloser = conglomerateCloserPair.rhs;
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException
+  {
+    resourceCloser.close();
+  }
+
+  @Before
+  public void setUp() throws Exception
+  {
+    walker = CalciteTests.createMockWalker(conglomerate, temporaryFolder.newFolder());
+  }
+
+  @After
+  public void tearDown() throws Exception
+  {
+    walker.close();
+    walker = null;
+  }
+
+  private void testQuery(
+      final PlannerConfig plannerConfig,
+      final Map<String, Object> queryContext,
+      final String sql,
+      final AuthenticationResult authenticationResult,
+      final int expectedFieldCount
+  ) throws Exception
+  {
+    log.info("SQL: %s", sql);
+    final InProcessViewManager viewManager = new InProcessViewManager(CalciteTests.TEST_AUTHENTICATOR_ESCALATOR);
+    final DruidSchema druidSchema = CalciteTests.createMockSchema(conglomerate, walker, plannerConfig, viewManager);
+    final SystemSchema systemSchema = CalciteTests.createMockSystemSchema(druidSchema, walker);
+    final DruidOperatorTable operatorTable = new DruidOperatorTable(
+        ImmutableSet.of(
+            new MockSqlLag(),
+            new MockSqlLead()
+        ), new HashSet<>());
+    final ExprMacroTable macroTable = CalciteTests.createExprMacroTable();
+
+    final PlannerFactory plannerFactory = new PlannerFactory(
+        druidSchema,
+        systemSchema,
+        CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
+        operatorTable,
+        macroTable,
+        plannerConfig,
+        CalciteTests.TEST_AUTHORIZER_MAPPER,
+        CalciteTests.getJsonMapper()
+    );
+
+    try (DruidPlanner planner = plannerFactory.createPlanner(queryContext)) {
+      final PlannerResult plan = planner.plan(sql, authenticationResult);
+      assertTrue(plan != null);
+      assertTrue(plan.rowType().getFieldCount() == expectedFieldCount);
+    }
+  }
+
+  @Test
+  public void testWindowQuery_succeed() throws Exception
+  {
+    Map<String, Object> queryContext = new HashMap<>(QUERY_CONTEXT_DEFAULT);
+    queryContext.put(DruidQuery.WINDOW_QUERY_CONTEXT_NAME,
+                     DruidQuery.WINDOW_QUERY_TEST_CONTEXT + ":org.apache.druid.sql.calcite.window.MockWindowQueryFactory");
+
+    String sql = "SELECT lag(dim1) OVER (), dim1, lead(dim1) OVER () from foo";
+    testQuery(PLANNER_CONFIG_DEFAULT, queryContext, sql, CalciteTests.REGULAR_USER_AUTH_RESULT, 3);
+
+    sql = "SELECT lag(dim1) OVER (), dim1, lead(dim2) OVER (), dim2 from foo";
+    testQuery(PLANNER_CONFIG_DEFAULT, queryContext, sql, CalciteTests.REGULAR_USER_AUTH_RESULT, 4);
+
+    sql = "SELECT lag(dim1) OVER (partition by cnt), dim1, lead(dim2) OVER (partition by cnt), dim2, cnt from foo";
+    testQuery(PLANNER_CONFIG_DEFAULT, queryContext, sql, CalciteTests.REGULAR_USER_AUTH_RESULT, 5);
+  }
+
+  @Test
+  public void testWindowQuery_fail() throws Exception
+  {
+    Map<String, Object> queryContext = new HashMap<>(QUERY_CONTEXT_DEFAULT);
+    queryContext.put(
+        DruidQuery.WINDOW_QUERY_CONTEXT_NAME,
+        DruidQuery.WINDOW_QUERY_TEST_CONTEXT + ":org.apache.druid.sql.calcite.window.MockWindowQueryFactory"
+    );
+
+    String sql;
+    boolean failed = false;
+
+    // No `OVER` clause
+    try {
+      sql = "SELECT lag(dim1), dim1, lead(dim1) OVER () from foo";
+      testQuery(PLANNER_CONFIG_DEFAULT, queryContext, sql, CalciteTests.REGULAR_USER_AUTH_RESULT, 3);
+    }
+    catch (ValidationException exp) {
+      failed = true;
+      assertTrue(exp.getMessage().contains("OVER clause is necessary for window functions"));
+    }
+    assertTrue(failed);
+
+    // Different partition by clauses
+    try {
+      failed = false;
+      sql = "SELECT lag(dim1) OVER (partition by dim2), dim1, lead(dim1) OVER (), dim2, cnt from foo";
+      testQuery(PLANNER_CONFIG_DEFAULT, queryContext, sql, CalciteTests.REGULAR_USER_AUTH_RESULT, 4);
+    }
+    catch (RelOptPlanner.CannotPlanException exp) {
+      failed = true;
+    }
+    assertTrue(failed);
+  }
+}


### PR DESCRIPTION
This changelist adds window support to Druid sql module.

- DruidRules.rules() is modified to accept Window and Project on Window.
- DruidRules.DruidOuterQueryRule is modified to accept Window as subqueries.
- PartialDruidQuery is modified to accept Window and WindowProject.
- DruidQuery is modified to construct WindowBaseQuery or GroupByOverWindowBaseQuery
  when requested.
- The actual implementation of WindowBaseQuery and GroupByOverWindowBaseQuery is
  in au-druid repository.