### PR TITLE
Re-use existing selectors in ScanQuery and SelectQuery

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -49,6 +49,7 @@ import org.apache.druid.query.groupby.epinephelinae.column.LongGroupByColumnSele
 import org.apache.druid.query.groupby.epinephelinae.column.NullableValueGroupByColumnSelectorStrategy;
 import org.apache.druid.query.groupby.epinephelinae.column.StringGroupByColumnSelectorStrategy;
 import org.apache.druid.query.groupby.strategy.GroupByStrategyV2;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.DimensionHandlerUtils;
@@ -284,7 +285,7 @@ public class GroupByQueryEngineV2
     protected final GroupByColumnSelectorPlus[] dims;
     protected final DateTime timestamp;
 
-    protected final List<ColumnValueSelector> columnValueSelectors;
+    protected final List<BaseObjectColumnValueSelector> columnValueSelectors;
     protected CloseableGrouperIterator<KeyType, Row> delegate = null;
     protected final boolean allSingleValueDims;
     protected final AtomicLong numAuSignals;

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
@@ -34,7 +34,6 @@ import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.UsageUtils;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.BaseObjectColumnValueSelector;
-import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.VirtualColumn;
@@ -141,15 +140,6 @@ public class ScanQueryEngine
                       @Override
                       public Iterator<ScanResultValue> make()
                       {
-                        List<ColumnValueSelector> columnValueSelectors = UsageUtils.makeRequiredSelectors(
-                            null,
-                            query.getVirtualColumns(),
-                            query.getFilter(),
-                            null,
-                            query.getColumns(),
-                            cursor
-                        );
-
                         final List<BaseObjectColumnValueSelector> columnSelectors = new ArrayList<>(allColumns.size());
 
                         for (String column : allColumns) {
@@ -223,7 +213,7 @@ public class ScanQueryEngine
                               for (int j = 0; j < allColumns.size(); j++) {
                                 theEvent.add(getColumnValue(j));
                               }
-                              UsageUtils.incrementAuSignals((AtomicLong) responseContext.get(UsageUtils.NUM_AU_SIGNALS), columnValueSelectors);
+                              UsageUtils.incrementAuSignals((AtomicLong) responseContext.get(UsageUtils.NUM_AU_SIGNALS), columnSelectors);
                               events.add(theEvent);
                             }
                             return events;
@@ -238,7 +228,7 @@ public class ScanQueryEngine
                               for (int j = 0; j < allColumns.size(); j++) {
                                 theEvent.put(allColumns.get(j), getColumnValue(j));
                               }
-                              UsageUtils.incrementAuSignals((AtomicLong) responseContext.get(UsageUtils.NUM_AU_SIGNALS), columnValueSelectors);
+                              UsageUtils.incrementAuSignals((AtomicLong) responseContext.get(UsageUtils.NUM_AU_SIGNALS), columnSelectors);
                               events.add(theEvent);
                             }
                             return events;

--- a/processing/src/main/java/org/apache/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/select/SelectQueryEngine.java
@@ -232,14 +232,7 @@ public class SelectQueryEngine
           @Override
           public Result<SelectResultValue> apply(Cursor cursor)
           {
-            List<ColumnValueSelector> columnValueSelectors = UsageUtils.makeRequiredSelectors(
-                query.getDimensions(),
-                query.getVirtualColumns(),
-                query.getFilter(),
-                null,
-                query.getMetrics(),
-                cursor
-            );
+            List<BaseObjectColumnValueSelector> columnValueSelectors = new ArrayList<>();
 
             final SelectResultValueBuilder builder = new SelectResultValueBuilder(
                 cursor.getTime(),
@@ -260,12 +253,17 @@ public class SelectQueryEngine
               builder.addDimension(dimSpec.getOutputName());
             }
 
+            for (ColumnSelectorPlus<SelectColumnSelectorStrategy> selectorPlus : selectorPlusList) {
+              columnValueSelectors.add(selectorPlus.getSelector());
+            }
+
             final Map<String, BaseObjectColumnValueSelector<?>> metSelectors = Maps.newHashMap();
             for (String metric : metrics) {
               final BaseObjectColumnValueSelector<?> metricSelector =
                   cursor.getColumnSelectorFactory().makeColumnValueSelector(metric);
               metSelectors.put(metric, metricSelector);
               builder.addMetric(metric);
+              columnValueSelectors.add(metricSelector);
             }
 
             final PagingOffset offset = query.getPagingOffset(segmentId);

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryEngine.java
@@ -27,7 +27,7 @@ import org.apache.druid.query.UsageUtils;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.filter.Filter;
-import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.SegmentMissingException;
 import org.apache.druid.segment.StorageAdapter;
@@ -90,7 +90,7 @@ public class TimeseriesQueryEngine
               return null;
             }
 
-            List<ColumnValueSelector> columnValueSelectors = UsageUtils.makeRequiredSelectors(
+            List<BaseObjectColumnValueSelector> columnValueSelectors = UsageUtils.makeRequiredSelectors(
                 null,
                 query.getVirtualColumns(),
                 query.getFilter(),


### PR DESCRIPTION
ScanQuery and SelectQuery already construct a list of selectors. This changelist
re-uses those selectors instead of creating new ones.